### PR TITLE
Support Ceph multitenancy bucket naming format project_id:bucket_name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Image to build geesefs for ubuntu 18
+# USE instructions
+# chcon -Rt svirt_sandbox_file_t .
+# sudo docker run -it -v $PWD:/work gb bash
+# (inside container) go build
+
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y git wget
+ADD . /work
+WORKDIR /work
+RUN wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz && tar -xvf go1.16.4.linux-amd64.tar.gz && mv go /usr/local
+RUN ln -s /usr/local/go/bin/go /usr/bin/go

--- a/api/api.go
+++ b/api/api.go
@@ -31,6 +31,7 @@ import (
 var log = GetLogger("main")
 
 func Mount(
+
 	ctx context.Context,
 	bucketName string,
 	flags *FlagStorage) (fs *Goofys, mfs *fuse.MountedFileSystem, err error) {

--- a/api/common/config.go
+++ b/api/common/config.go
@@ -46,6 +46,7 @@ type FlagStorage struct {
 	// Common Backend Config
 	UseContentType bool
 	Endpoint       string
+  ProjectId      string
 	Backend        interface{}
 
 	// Tuning

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -64,6 +64,12 @@ func NewS3(bucket string, flags *FlagStorage, config *S3Config) (*S3Backend, err
 	if config.MultipartCopyThreshold == 0 {
 		config.MultipartCopyThreshold = 128*1024*1024
 	}
+
+  if(flags.ProjectId != "" ) {
+    log.Infof("Using Ceph multitenancy format bucket naming: %s", bucket)
+    bucket = flags.ProjectId+":"+bucket
+  }
+
 	awsConfig, err := config.ToAwsConfig(flags)
 	if err != nil {
 		return nil, err

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -143,6 +143,12 @@ func NewApp() (app *cli.App) {
 				" Possible values: http://127.0.0.1:8081/, https://s3.amazonaws.com",
 		},
 
+    cli.StringFlag{
+			Name:  "project-id",
+			Value: "",
+			Usage: "Propject id for CEPH multi-tenancy bucket sharing (bucket syntax project-id:bucket-name)",
+		},
+
 		cli.BoolFlag{
 			Name:  "iam",
 			Usage: "Try to authenticate automatically using VM metadata service (Yandex Cloud / IMDSv1)",
@@ -629,6 +635,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 
 		// Common Backend Config
 		Endpoint:               c.String("endpoint"),
+    ProjectId:              c.String("project-id"),
 		UseContentType:         c.Bool("use-content-type"),
 
 		// Debugging,


### PR DESCRIPTION
Don't know how you handle contributions, but I added flag to handle Ceph multi tenancy (https://docs.ceph.com/en/latest/radosgw/multitenancy/), and would be great to the official version. 
