### PR TITLE
add support for Linux arm64

### DIFF
--- a/api/common/logger.go
+++ b/api/common/logger.go
@@ -59,7 +59,7 @@ func InitLoggers(logFile string) {
 		for _, l := range loggers {
 			l.Out = file
 		}
-		err = syscall.Dup2(int(file.Fd()), int(os.Stderr.Fd()))
+		err = syscall.Dup3(int(file.Fd()), int(os.Stderr.Fd()), 0)
 		if err != nil {
 			log.Errorf("Couldn't redirect STDERR to the log file %v", logFile)
 			return


### PR DESCRIPTION
Linux arm64 platform doesn't have syscall.Dup2
so I changed it to the nearly identical syscall.Dup3