### PR TITLE
Upgrade to S3Proxy 2.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ xfstests:
 	cd xfstests && patch -p1 -l < ../test/xfstests.diff
 
 s3proxy.jar:
-	wget https://github.com/gaul/s3proxy/releases/download/s3proxy-1.8.0/s3proxy -O s3proxy.jar
+	wget https://github.com/gaul/s3proxy/releases/download/s3proxy-2.1.0/s3proxy -O s3proxy.jar
 
 get-deps: s3proxy.jar
 	go get -t ./...


### PR DESCRIPTION
This resolves issues with newer Java versions of the form:

```
module java.base does not "opens java.lang" to unnamed module
```