### PR TITLE
<bugfix> fix inode refcnt

### DIFF
--- a/core/goofys_fuse.go
+++ b/core/goofys_fuse.go
@@ -395,7 +395,10 @@ func (fs *GoofysFuse) ReadDir(
 			if n == 0 {
 				break
 			}
-			e.Ref()
+			// readdirPlus will not increase nlookup for . and ..
+			if e != dh.inode && e != dh.inode.Parent {
+				e.Ref()
+			}
 		} else {
 			e.mu.Lock()
 			dirent = makeDirEntry(e, dh.lastExternalOffset)


### PR DESCRIPTION
readdirplus do not increase nlookup for . and ..
so we do not increace refcnt for dh.inode and dh.parent


----
## TO Reproduce

```bash
mkdir -p a/b/c/
touch a/b/c/file
ls a a/b a/b/c
rm -rf a
```
then check fs.inodes, dir a, dir a/b dir a/b/c will not be forgotten due to refcnt leak.


## Ref

readdir plus in fuse kernel
```c
static int fuse_direntplus_link(struct file *file,
                                struct fuse_direntplus *direntplus,
                                u64 attr_version)
{
        struct fuse_entry_out *o = &direntplus->entry_out;
        struct fuse_dirent *dirent = &direntplus->dirent;
        struct dentry *parent = file->f_path.dentry;
        struct qstr name = QSTR_INIT(dirent->name, dirent->namelen);
        struct dentry *dentry;
        struct dentry *alias;
        struct inode *dir = d_inode(parent);
        struct fuse_conn *fc;
        struct inode *inode;
        DECLARE_WAIT_QUEUE_HEAD_ONSTACK(wq);

        if (!o->nodeid) {
                /*
                 * Unlike in the case of fuse_lookup, zero nodeid does not mean
                 * ENOENT. Instead, it only means the userspace filesystem did
                 * not want to return attributes/handle for this entry.
                 *
                 * So do nothing.
                 */
                return 0;
        }

        if (name.name[0] == '.') {
                /*
                 * We could potentially refresh the attributes of the directory
                 * and its parent?
                 */
                if (name.len == 1)
                        return 0;
                if (name.name[1] == '.' && name.len == 2)
                        return 0;
        }

       ....
       ....
       ....
       ....
                fi->nlookup++;
                    ....
       ....
       ....
       ....
       ....
       ....
        return 0;
}
```