### PR TITLE
Add --no-evict-root-childs flag

### DIFF
--- a/core/cfg/config.go
+++ b/core/cfg/config.go
@@ -108,6 +108,7 @@ type FlagStorage struct {
 	NoPreloadDir        bool
 	NoVerifySSL         bool
 	WinRefreshDirs      bool
+	NoEvictRootChilds   bool
 
 	// Debugging
 	DebugMain  bool

--- a/core/cfg/flags.go
+++ b/core/cfg/flags.go
@@ -619,6 +619,11 @@ MISC OPTIONS:
 			Value: 512,
 			Usage: "Simultaneously opened cache file descriptor limit",
 		},
+		cli.BoolFlag{
+			Name: "no-evict-root-childs",
+			Usage: "Do not evict inode if it parent is RootInode." +
+			  " Useful if you mount one bucket and docker mount the bucket's child folders.",
+		},
 	}
 
 	if runtime.GOOS == "windows" {
@@ -876,6 +881,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		PreferPatchUploads:  c.Bool("prefer-patch-uploads"),
 		NoPreloadDir:        c.Bool("no-preload-dir"),
 		NoVerifySSL:         c.Bool("no-verify-ssl"),
+		NoEvictRootChilds:   c.Bool("no-evict-root-childs"),
 
 		// Common Backend Config
 		Endpoint:       c.String("endpoint"),

--- a/core/goofys.go
+++ b/core/goofys.go
@@ -684,6 +684,13 @@ func (fs *Goofys) EvictEntry(id fuseops.InodeID) bool {
 		childTmp.isDir() && atomic.LoadInt64(&childTmp.dir.ModifiedChildren) > 0 {
 		return false
 	}
+	// Do not evict inode if it parent is RootInode
+  if fs.flags.NoEvictRootChilds && childTmp.Parent.Id == fuseops.RootInodeID {
+	  log.Debugf("Do not evict root child: inode %v, name %v, parent inode %v", childTmp.Id, childTmp.Name, childTmp.Parent.Id)
+		childNewExprTime := time.Now()
+		childTmp.SetExpireTime(childNewExprTime)
+		return false
+	}
 	if !childTmp.mu.TryLock() {
 		return false
 	}


### PR DESCRIPTION
Added the `--no-evict-root-childs` flag. It prevents eviction of child directories of the root inode and updates their `ExpiredTime`. It seems to work fine, but there is a small bug: when `--entry-limit` is small (less than the number of child directories), MetaEvictor starts an infinite loop of eviction attempts. When `--entry-limit` is large, everything works fine.
If one bucket is mounted and child folders are mounted as a volume in docker, geesefs crashed with the error "Bad file descriptor" after MetaEvictor ran. After I excluded evicting child folders, the error no longer appears.
But I'm sure that the error will repeat if you mount a child folder of a child folder in docker. That is, for example, `/mnt/data` is the mount point of the bucket. Then mounting /mnt/data/dir1 in docker will not cause an error, but `/mnt/data/dir1/subdir1` will.