### PR TITLE
Fix panic in partRange when uploading exactly 10000 parts

### DIFF
--- a/core/file.go
+++ b/core/file.go
@@ -76,7 +76,7 @@ func (fs *Goofys) partRange(num uint64) (offset uint64, size uint64) {
 	n := uint64(0)
 	start := uint64(0)
 	for _, s := range fs.flags.PartSizes {
-		if num < n+s.PartCount {
+		if num <= n+s.PartCount {
 			return start + (num-n)*s.PartSize, s.PartSize
 		}
 		start += s.PartSize * s.PartCount


### PR DESCRIPTION
The partRange method incorrectly handled the upper boundary (10000 parts), causing a panic during large multipart uploads. Adjusted the logic to properly process the maximum allowed parts.

Closes #148