### PR TITLE
fix(s3): URI escaping in VHS mode

### DIFF
--- a/core/backend_s3.go
+++ b/core/backend_s3.go
@@ -38,6 +38,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/corehandlers"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/rest"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -270,6 +271,11 @@ func (s *S3Backend) newS3() {
 		Name: "core.SDKVersionUserAgentHandler",
 		Fn: request.MakeAddToUserAgentHandler("GeeseFS", cfg.GEESEFS_VERSION,
 			runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	})
+	s.S3.Handlers.Build.PushBack(func(req *request.Request) {
+		if s.config.Subdomain && req.HTTPRequest.URL.Path != "" {
+			req.HTTPRequest.URL.RawPath = rest.EscapePath(req.HTTPRequest.URL.Path, false)
+		}
 	})
 }
 

--- a/core/backend_s3.go
+++ b/core/backend_s3.go
@@ -273,7 +273,7 @@ func (s *S3Backend) newS3() {
 			runtime.Version(), runtime.GOOS, runtime.GOARCH),
 	})
 	s.S3.Handlers.Build.PushBack(func(req *request.Request) {
-		if s.config.Subdomain && req.HTTPRequest.URL.Path != "" {
+		if s.config.Subdomain {
 			req.HTTPRequest.URL.RawPath = rest.EscapePath(req.HTTPRequest.URL.Path, false)
 		}
 	})


### PR DESCRIPTION
Added forced URL escaping to fix potential aws-sdk-go(v1) signature mismatch issue (probably fixed in v2).