### PR TITLE
Fix multipart part boundary handling without allowing out-of-range parts

### DIFF
--- a/core/file.go
+++ b/core/file.go
@@ -72,17 +72,36 @@ func (fs *Goofys) partNum(offset uint64) uint64 {
 	))
 }
 
+func (fs *Goofys) numParts(size uint64) uint64 {
+	part := fs.partNum(size)
+	if part == fs.maxParts() {
+		return part
+	}
+	partOffset, _ := fs.partRange(part)
+	if partOffset < size {
+		part++
+	}
+	return part
+}
+
 func (fs *Goofys) partRange(num uint64) (offset uint64, size uint64) {
 	n := uint64(0)
 	start := uint64(0)
 	for _, s := range fs.flags.PartSizes {
-		if num <= n+s.PartCount {
+		if num < n+s.PartCount {
 			return start + (num-n)*s.PartSize, s.PartSize
 		}
 		start += s.PartSize * s.PartCount
 		n += s.PartCount
 	}
 	panic(fmt.Sprintf("Part number too large: %v", num))
+}
+
+func (fs *Goofys) maxParts() (parts uint64) {
+	for _, s := range fs.flags.PartSizes {
+		parts += s.PartCount
+	}
+	return parts
 }
 
 func (fs *Goofys) getMaxFileSize() (size uint64) {
@@ -1739,11 +1758,7 @@ func (inode *Inode) completeMultipart() {
 		return
 	}
 	finalSize := inode.Attributes.Size
-	numParts := inode.fs.partNum(finalSize)
-	numPartOffset, _ := inode.fs.partRange(numParts)
-	if numPartOffset < finalSize {
-		numParts++
-	}
+	numParts := inode.fs.numParts(finalSize)
 	err := inode.copyUnmodifiedParts(numParts)
 	if !(inode.CacheState == ST_CREATED || inode.CacheState == ST_MODIFIED) {
 		// State changed, abort this flush (even if we get ENOENT)

--- a/core/part_size_test.go
+++ b/core/part_size_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/yandex-cloud/geesefs/core/cfg"
+)
+
+func TestPartRangeTierBoundaries(t *testing.T) {
+	flags := cfg.DefaultFlags()
+	fs := &Goofys{flags: flags}
+
+	const MiB = uint64(1024 * 1024)
+
+	checks := []struct {
+		part       uint64
+		wantOffset uint64
+		wantSize   uint64
+	}{
+		{part: 999, wantOffset: 4995 * MiB, wantSize: 5 * MiB},
+		{part: 1000, wantOffset: 5000 * MiB, wantSize: 25 * MiB},
+		{part: 1001, wantOffset: 5025 * MiB, wantSize: 25 * MiB},
+		{part: 1999, wantOffset: 29975 * MiB, wantSize: 25 * MiB},
+		{part: 2000, wantOffset: 30000 * MiB, wantSize: 125 * MiB},
+	}
+
+	for _, check := range checks {
+		offset, size := fs.partRange(check.part)
+		if offset != check.wantOffset || size != check.wantSize {
+			t.Fatalf("partRange(%d) = (%d, %d), want (%d, %d)",
+				check.part, offset, size, check.wantOffset, check.wantSize)
+		}
+	}
+}
+
+func TestNumPartsOnPartBoundaries(t *testing.T) {
+	flags := cfg.DefaultFlags()
+	fs := &Goofys{flags: flags}
+
+	const MiB = uint64(1024 * 1024)
+
+	checks := []struct {
+		size uint64
+		want uint64
+	}{
+		{size: 0, want: 0},
+		{size: 1, want: 1},
+		{size: 5 * MiB, want: 1},
+		{size: 5*MiB + 1, want: 2},
+		{size: 5000 * MiB, want: 1000},
+		{size: 5000*MiB + 1, want: 1001},
+		{size: 5025 * MiB, want: 1001},
+		{size: 30000 * MiB, want: 2000},
+		{size: fs.getMaxFileSize(), want: 10000},
+	}
+
+	for _, check := range checks {
+		parts := fs.numParts(check.size)
+		if parts != check.want {
+			t.Fatalf("numParts(%d) = %d, want %d", check.size, parts, check.want)
+		}
+	}
+}
+
+func TestNumPartsWithTenThousandFiveMiBParts(t *testing.T) {
+	const MiB = uint64(1024 * 1024)
+
+	flags := cfg.DefaultFlags()
+	flags.PartSizes = []cfg.PartSizeConfig{
+		{PartSize: 5 * MiB, PartCount: 10000},
+	}
+	fs := &Goofys{flags: flags}
+
+	const fileSize = 50000 * MiB
+
+	if got := fs.partNum(fileSize); got != 10000 {
+		t.Fatalf("partNum(%d) = %d, want 10000", fileSize, got)
+	}
+	if got := fs.numParts(fileSize); got != 10000 {
+		t.Fatalf("numParts(%d) = %d, want 10000", fileSize, got)
+	}
+
+	offset, size := fs.partRange(9999)
+	if offset != 49995*MiB || size != 5*MiB {
+		t.Fatalf("partRange(9999) = (%d, %d), want (%d, %d)",
+			offset, size, uint64(49995)*MiB, uint64(5)*MiB)
+	}
+
+	assertPanics(t, func() {
+		fs.partRange(10000)
+	})
+}
+
+func assertPanics(t *testing.T, f func()) {
+	t.Helper()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("function did not panic")
+		}
+	}()
+
+	f()
+}


### PR DESCRIPTION
This PR fixes a data-loss regression introduced in #149 while addressing the exact 10,000-part upload case.

The regression changed the part range boundary check from strict to inclusive in [partRange()](https://github.com/yandex-cloud/geesefs/blob/master/core/file.go#L79). As a result, the first part of each next part-size tier was incorrectly treated as the last part of the previous tier. With the default configuration this made part 1000 use a 5 MiB range instead of a 25 MiB range, so the 20 MiB range between 5005 MiB and 5025 MiB was skipped during upload. Files crossing that boundary could therefore be uploaded corrupted and smaller than the original file.

This PR restores strict boundary handling in [partRange()](https://github.com/yandex-cloud/geesefs/blob/master/core/file.go#L79) and moves exact-boundary part counting into `numParts()`, so uploads with exactly 10,000 parts no longer panic without making part 10000 a valid data part.

Added unit tests for:

mixed part-size tier boundaries;
exact-boundary part counting;
the original #149 scenario: 10,000 parts of 5 MiB each.