### PR TITLE
Refresh IAM token lazily so it survives a long process pause

### DIFF
--- a/core/backend_s3.go
+++ b/core/backend_s3.go
@@ -29,6 +29,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -59,6 +60,8 @@ type S3Backend struct {
 	iamToken           atomic.Value
 	iamTokenExpiration time.Time
 	iamRefreshTimer    *time.Timer
+	iamMu              sync.Mutex
+	iamTokenExpUnix    atomic.Int64
 }
 
 func NewS3(bucket string, flags *cfg.FlagStorage, config *cfg.S3Config) (*S3Backend, error) {
@@ -191,6 +194,7 @@ func (s *S3Backend) TryIAM() (err error) {
 	s.iam = true
 	s.iamToken.Store(token)
 	s.iamTokenExpiration = now.Add(ttl)
+	s.iamTokenExpUnix.Store(now.Add(ttl).UnixNano())
 	if ttl > 5*time.Minute {
 		ttl = ttl - 5*time.Minute
 	} else if ttl > 30*time.Second {
@@ -204,11 +208,52 @@ func (s *S3Backend) TryIAM() (err error) {
 }
 
 func (s *S3Backend) RefreshIAM() {
+	s.iamMu.Lock()
+	defer s.iamMu.Unlock()
 	err := s.TryIAM()
 	if err != nil {
 		s.iamRefreshTimer = time.AfterFunc(10*time.Second, func() {
 			s.RefreshIAM()
 		})
+	}
+}
+
+// iamLazyRefreshMargin is the wall-clock head start used by the on-demand
+// refresh. It is kept small relative to the background timer's typical head
+// start (see TryIAM, ~5 min for long-lived tokens) so the background timer
+// normally refreshes first and this path stays a fallback. For very
+// short-lived tokens the background head start can be smaller; that is
+// acceptable because either path produces a valid token.
+const iamLazyRefreshMargin = 60 * time.Second
+
+// ensureFreshIAMToken refreshes the IAM token on demand when it is close to
+// expiry by wall-clock time. The background refresh relies on time.AfterFunc,
+// whose deadline is measured against the monotonic clock. If the process is
+// paused for a long time (e.g. a suspended or migrated VM), the monotonic
+// clock does not advance during the pause while wall-clock time does, so the
+// timer can fire too late and the token may already be expired when execution
+// resumes. This check compares against a wall-clock deadline (time.Now().UnixNano()
+// uses only the wall clock, with no monotonic component) and runs from the
+// request signer, i.e. on the hot path that executes after the process
+// resumes. It is a best-effort safety net that assumes the wall clock is
+// reasonably accurate after a resume; it does not replace the background timer.
+func (s *S3Backend) ensureFreshIAMToken() {
+	// exp == 0 means TryIAM has never stored a deadline (IAM disabled, or the
+	// initial fetch failed and the retry timer owns recovery). This fast path
+	// reads only the atomic deadline, so it needs no lock and cannot race with
+	// a concurrent refresh.
+	exp := s.iamTokenExpUnix.Load()
+	if exp == 0 || time.Now().UnixNano() < exp-int64(iamLazyRefreshMargin) {
+		return
+	}
+	s.iamMu.Lock()
+	defer s.iamMu.Unlock()
+	exp = s.iamTokenExpUnix.Load()
+	if exp == 0 || time.Now().UnixNano() < exp-int64(iamLazyRefreshMargin) {
+		return // refreshed by a concurrent caller
+	}
+	if err := s.TryIAM(); err != nil {
+		s3Log.Infof("Lazy IAM refresh failed: %v", err)
 	}
 }
 
@@ -218,6 +263,7 @@ func (s *S3Backend) setIAMSigner(handlers *request.Handlers) {
 		if req.Config.Credentials == credentials.AnonymousCredentials {
 			return
 		}
+		s.ensureFreshIAMToken()
 		req.HTTPRequest.Header.Set(s.config.IAMHeader, s.iamToken.Load().(string))
 	})
 	handlers.Sign.PushBackNamed(corehandlers.BuildContentLengthHandler)

--- a/core/backend_s3_iam_test.go
+++ b/core/backend_s3_iam_test.go
@@ -1,0 +1,294 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/yandex-cloud/geesefs/core/cfg"
+)
+
+// iamTokenServer is a hermetic stand-in for the GCP-flavored IAM metadata
+// endpoint. It counts requests and hands out a distinct token each time.
+// When fail is set it returns a broken response so TryIAM reports an error.
+//
+// Tests must keep expiresIn large enough that the background AfterFunc timer
+// (scheduled by TryIAM) cannot fire within the test run, otherwise it would
+// race the assertions and re-hit the server after Close.
+type iamTokenServer struct {
+	*httptest.Server
+	hits      atomic.Int64
+	fail      atomic.Bool
+	expiresIn int
+}
+
+func newIAMTokenServer(expiresIn int) *iamTokenServer {
+	srv := &iamTokenServer{expiresIn: expiresIn}
+	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := srv.hits.Add(1)
+		if srv.fail.Load() {
+			http.Error(w, "metadata unavailable", http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintf(w, `{"access_token":"token-%d","token_type":"Bearer","expires_in":%d}`, n, srv.expiresIn)
+	}))
+	return srv
+}
+
+func newIAMBackend(srv *iamTokenServer) *S3Backend {
+	return &S3Backend{
+		config: (&cfg.S3Config{
+			UseIAM:    true,
+			IAMFlavor: "gcp",
+			IAMUrl:    srv.URL,
+		}).Init(),
+	}
+}
+
+// stopRefreshTimer disables the background monotonic-clock timer so it cannot
+// add nondeterministic hits during the test.
+func stopRefreshTimer(s *S3Backend) {
+	if s.iamRefreshTimer != nil {
+		s.iamRefreshTimer.Stop()
+	}
+}
+
+func currentIAMToken(t *testing.T, s *S3Backend) string {
+	t.Helper()
+	v := s.iamToken.Load()
+	if v == nil {
+		t.Fatal("IAM token is not set")
+	}
+	return v.(string)
+}
+
+func expireIAMTokenInThePast(s *S3Backend) {
+	s.iamTokenExpUnix.Store(time.Now().Add(-time.Hour).UnixNano())
+}
+
+// TestIAMLazyRefreshOnFrozenTimer reproduces the suspended-VM scenario: the
+// background AfterFunc (monotonic clock) never fired, the token expired by
+// wall-clock time, and the lazy refresh must pick it up.
+func TestIAMLazyRefreshOnFrozenTimer(t *testing.T) {
+	srv := newIAMTokenServer(3600)
+	defer srv.Close()
+	s := newIAMBackend(srv)
+
+	if err := s.TryIAM(); err != nil {
+		t.Fatalf("TryIAM: %v", err)
+	}
+	stopRefreshTimer(s)
+	if got := srv.hits.Load(); got != 1 {
+		t.Fatalf("hits after TryIAM = %d, want 1", got)
+	}
+	tokenBefore := currentIAMToken(t, s)
+
+	// Emulate: wall-clock advanced past expiry while the monotonic timer
+	// stayed frozen, so the deadline is now in the past.
+	expireIAMTokenInThePast(s)
+
+	s.ensureFreshIAMToken()
+	stopRefreshTimer(s)
+
+	if got := srv.hits.Load(); got != 2 {
+		t.Fatalf("hits after lazy refresh = %d, want 2", got)
+	}
+	if tokenAfter := currentIAMToken(t, s); tokenAfter == tokenBefore {
+		t.Fatalf("token was not refreshed, still %q", tokenAfter)
+	}
+}
+
+// TestIAMLazyRefreshConcurrent verifies the double-checked locking: many
+// concurrent callers on an expired token trigger exactly one refresh.
+func TestIAMLazyRefreshConcurrent(t *testing.T) {
+	srv := newIAMTokenServer(3600)
+	defer srv.Close()
+	s := newIAMBackend(srv)
+
+	if err := s.TryIAM(); err != nil {
+		t.Fatalf("TryIAM: %v", err)
+	}
+	stopRefreshTimer(s)
+	expireIAMTokenInThePast(s)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			s.ensureFreshIAMToken()
+		}()
+	}
+	wg.Wait()
+	stopRefreshTimer(s)
+
+	if got := srv.hits.Load(); got != 2 {
+		t.Fatalf("hits = %d, want 2 (1 initial + exactly 1 lazy refresh)", got)
+	}
+}
+
+// TestIAMLazyRefreshSkippedWhenFresh verifies the fast path does not hit the
+// metadata server while the token is still valid.
+func TestIAMLazyRefreshSkippedWhenFresh(t *testing.T) {
+	srv := newIAMTokenServer(3600)
+	defer srv.Close()
+	s := newIAMBackend(srv)
+
+	if err := s.TryIAM(); err != nil {
+		t.Fatalf("TryIAM: %v", err)
+	}
+	stopRefreshTimer(s)
+
+	s.ensureFreshIAMToken()
+	stopRefreshTimer(s)
+
+	if got := srv.hits.Load(); got != 1 {
+		t.Fatalf("hits = %d, want 1 (no refresh for a fresh token)", got)
+	}
+}
+
+// TestIAMLazyRefreshMarginBoundary checks that the refresh fires proactively
+// once the deadline is within iamLazyRefreshMargin, but not earlier. A sign
+// error in exp-int64(iamLazyRefreshMargin) would defeat the whole fix yet
+// still pass the other tests, so this boundary is asserted explicitly.
+func TestIAMLazyRefreshMarginBoundary(t *testing.T) {
+	cases := []struct {
+		name        string
+		untilExpiry time.Duration
+		wantRefresh bool
+	}{
+		{"inside margin", iamLazyRefreshMargin / 2, true},
+		{"outside margin", 10 * time.Minute, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newIAMTokenServer(3600)
+			defer srv.Close()
+			s := newIAMBackend(srv)
+			if err := s.TryIAM(); err != nil {
+				t.Fatalf("TryIAM: %v", err)
+			}
+			stopRefreshTimer(s)
+
+			s.iamTokenExpUnix.Store(time.Now().Add(tc.untilExpiry).UnixNano())
+			s.ensureFreshIAMToken()
+			stopRefreshTimer(s)
+
+			want := int64(1)
+			if tc.wantRefresh {
+				want = 2
+			}
+			if got := srv.hits.Load(); got != want {
+				t.Fatalf("hits = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestEnsureFreshIAMTokenNoopWhenUninitialized verifies the exp == 0 fast
+// path: with no successful TryIAM, the lazy refresh must be a pure no-op and
+// must not panic (no token has ever been stored).
+func TestEnsureFreshIAMTokenNoopWhenUninitialized(t *testing.T) {
+	srv := newIAMTokenServer(3600)
+	defer srv.Close()
+	s := newIAMBackend(srv) // TryIAM never called -> iamTokenExpUnix == 0
+
+	s.ensureFreshIAMToken()
+	stopRefreshTimer(s)
+
+	if got := srv.hits.Load(); got != 0 {
+		t.Fatalf("uninitialized IAM must not trigger a fetch, hits = %d", got)
+	}
+}
+
+// TestIAMLazyRefreshKeepsStaleTokenOnError pins the fallback contract: when
+// the metadata endpoint is broken, a lazy refresh must keep the last good
+// token, must not advance the deadline (so the next request retries instead
+// of going quiet), and must recover once the endpoint is healthy again.
+func TestIAMLazyRefreshKeepsStaleTokenOnError(t *testing.T) {
+	srv := newIAMTokenServer(3600)
+	defer srv.Close()
+	s := newIAMBackend(srv)
+
+	if err := s.TryIAM(); err != nil {
+		t.Fatalf("TryIAM: %v", err)
+	}
+	stopRefreshTimer(s)
+	tokenBefore := currentIAMToken(t, s)
+
+	srv.fail.Store(true)
+	expireIAMTokenInThePast(s)
+	expBefore := s.iamTokenExpUnix.Load()
+
+	s.ensureFreshIAMToken() // must not panic
+	stopRefreshTimer(s)
+
+	if got := currentIAMToken(t, s); got != tokenBefore {
+		t.Fatalf("stale token must be kept on refresh failure, got %q want %q", got, tokenBefore)
+	}
+	if got := s.iamTokenExpUnix.Load(); got != expBefore {
+		t.Fatalf("deadline must not advance on failure, else the next request stops retrying")
+	}
+
+	srv.fail.Store(false)
+	s.ensureFreshIAMToken()
+	stopRefreshTimer(s)
+
+	if got := currentIAMToken(t, s); got == tokenBefore {
+		t.Fatalf("token must refresh once the metadata endpoint recovers")
+	}
+}
+
+// TestSetIAMSignerRefreshesAndSetsHeader exercises the real integration point:
+// signing a non-anonymous request must trigger a lazy refresh when the token
+// is stale and put the refreshed token into the IAM header, while an
+// anonymous request must neither refresh nor set the header.
+func TestSetIAMSignerRefreshesAndSetsHeader(t *testing.T) {
+	srv := newIAMTokenServer(3600)
+	defer srv.Close()
+	s := newIAMBackend(srv)
+
+	if err := s.TryIAM(); err != nil {
+		t.Fatalf("TryIAM: %v", err)
+	}
+	stopRefreshTimer(s)
+	expireIAMTokenInThePast(s)
+
+	handlers := &request.Handlers{}
+	s.setIAMSigner(handlers)
+
+	signReq := func(creds *credentials.Credentials) *http.Request {
+		httpReq, _ := http.NewRequest("GET", "http://example.invalid/", nil)
+		req := &request.Request{
+			Config:      aws.Config{Credentials: creds},
+			HTTPRequest: httpReq,
+		}
+		handlers.Sign.Run(req)
+		stopRefreshTimer(s)
+		return httpReq
+	}
+
+	anonReq := signReq(credentials.AnonymousCredentials)
+	if got := srv.hits.Load(); got != 1 {
+		t.Fatalf("anonymous request must not trigger a refresh, hits = %d", got)
+	}
+	if h := anonReq.Header.Get(s.config.IAMHeader); h != "" {
+		t.Fatalf("anonymous request must not set the IAM header, got %q", h)
+	}
+
+	signedReq := signReq(credentials.NewStaticCredentials("ak", "sk", ""))
+	if got := srv.hits.Load(); got != 2 {
+		t.Fatalf("signing an expired-token request must trigger lazy refresh, hits = %d", got)
+	}
+	if h := signedReq.Header.Get(s.config.IAMHeader); h != "token-2" {
+		t.Fatalf("refreshed token must land in the IAM header, got %q", h)
+	}
+}


### PR DESCRIPTION
The IAM bearer token was refreshed only by a background time.AfterFunc. That timer's deadline is measured against the monotonic clock. If the process is paused for a long time (e.g. a suspended or migrated VM), the monotonic clock does not advance during the pause while wall-clock time does, so the timer can fire too late and the token may already be expired by wall-clock time when execution resumes. S3 then rejects the request with 403.

Additionally store the token deadline as a wall-clock value (time.Now().UnixNano(), which has no monotonic component) and lazily re-acquire the token from the request signer when that deadline is near. The signer runs on the hot path after the process resumes, so it is a best-effort trigger independent of the possibly-late timer. The background timer remains the primary refresh path; the lazy path uses a smaller margin and is only a safety net. Both refresh paths are serialized through a mutex, and the wall-clock deadline is read via an atomic on the lock-free fast path.